### PR TITLE
Compatibility with Xcode 7

### DIFF
--- a/lib/simctl-extensions.js
+++ b/lib/simctl-extensions.js
@@ -31,15 +31,24 @@ var shell = require('shelljs'),
 
 var extensions = {
     start : function(deviceid) {
+        var executable;
+
+        // The Simulator executable name depends on Xcode version, this keeps backwards compatibility
+        if (shell.exec('osascript -e \'id of application "iOS Simulator"\'', {silent: true}).code == 0) {
+            executable = 'iOS Simulator';
+        } else if (shell.exec('osascript -e \'id of application "Simulator"\'', {silent: true}).code == 0) {
+            executable = 'Simulator';
+        }
+
+        var command = 'open -a "' + executable + '"';
         if (!deviceid) {
-            var command = 'open -a "iOS Simulator"';
             return shell.exec(command, { silent: true } );
         } else {
-            var command = util.format('open -a "iOS Simulator" --args -CurrentDeviceUDID %s', deviceid);
+            command += util.format(command + ' --args -CurrentDeviceUDID %s', deviceid);
             return shell.exec(command, { silent: true } );
         }
     },
-    
+
     log : function(deviceid, filepath) {
         var tail = new Tail(
             path.join(process.env.HOME, 'Library/Logs/CoreSimulator', deviceid, 'system.log')
@@ -61,7 +70,7 @@ var extensions = {
         tail.on("error", function(error) {
             console.error('ERROR: ', error);
         });
-        
+
         return tail;
     }
 };


### PR DESCRIPTION
Recent update to Xcode renamed the version of the executable, so the `open -a "iOS Simulator"` should be changed to `open -a "Simulator"`.